### PR TITLE
Create nginx-docker-bridged-l7-path

### DIFF
--- a/marathon/nginx/nginx-docker-bridged-l7-path
+++ b/marathon/nginx/nginx-docker-bridged-l7-path
@@ -1,0 +1,52 @@
+{
+  "id": "/path/nginx-bridge-path-a",
+  "cmd": "env | sort && nginx -g \"daemon off;\"",
+  "instances": 1,
+  "cpus": 0.01,
+  "mem": 32,
+  "backoffSeconds": 1,
+  "backoffFactor": 1.15,
+  "maxLaunchDelaySeconds": 3600,
+  "container": {
+    "type": "DOCKER",
+    "volumes": [],
+    "docker": {
+      "image": "nginx:alpine",
+      "network": "BRIDGE",
+      "portMappings": [
+        {
+          "containerPort": 80,
+          "hostPort": 0,
+          "servicePort": 10101,
+          "protocol": "tcp",
+          "name": "http"
+          }
+      ],
+      "privileged": false,
+      "forcePullImage": false
+    }
+  },
+  "healthChecks": [
+    {
+      "path": "/",
+      "protocol": "HTTP",
+      "portIndex": 0,
+      "gracePeriodSeconds": 20,
+      "intervalSeconds": 20,
+      "timeoutSeconds": 20,
+      "maxConsecutiveFailures": 3,
+      "ignoreHttp1xx": false
+    }
+  ],
+  "upgradeStrategy": {
+    "minimumHealthCapacity": 1,
+    "maximumOverCapacity": 1
+  },
+  "labels": {
+    "HAPROXY_0_VHOST": "thomaskra-publicsl-1bgxuh9o7anky-1226212428.us-west-2.elb.amazonaws.com",
+    "HAPROXY_GROUP": "external",
+    "HAPROXY_0_PATH": "/nginxpath"
+    "HAPROXY_0_HTTP_BACKEND_PROXYPASS_PATH": "/nginxpath"
+  },
+  "requirePorts": false
+}


### PR DESCRIPTION
Allowing HTTP L7 Path information to be considered for routing requests to the same VHOST to different Marathon Applications.
http://thomaskra-publicsl.us-west-2.elb.amazonaws.com/nginxpath   ---> Marathon App A
http://thomaskra-publicsl.us-west-2.elb.amazonaws.com/corpmenu   ---> Marathon App B
So you dont have to setup a new A record every time you add an application to MLB