### PR TITLE
Adds node draining helper via pod replace

### DIFF
--- a/ops/pod_replace_drain_agent.sh
+++ b/ops/pod_replace_drain_agent.sh
@@ -7,7 +7,7 @@ function mesos_agent_get_tasks () {
     -H "Authorization: token=$(dcos config show core.dcos_acs_token)" \
     -H "Content-Type: application/json" \
     "$(dcos config show core.dcos_url)/mesos/state" | \
-  jq -er ".frameworks[].tasks[] | select(.slave_id==\"${agent_id}\") | {id: .id, name: .name, framework_id: .framework_id, executor_id: .executor_id, state: .state}"
+  jq -er ".frameworks[].tasks[] | select(.slave_id==\"${agent_id}\") | select(.state==\"TASK_RUNNING\") | {id: .id, name: .name, framework_id: .framework_id, executor_id: .executor_id, state: .state}"
 }
 
 function mesos_framework_name_for_id() {

--- a/ops/pod_replace_drain_agent.sh
+++ b/ops/pod_replace_drain_agent.sh
@@ -1,0 +1,40 @@
+#!bash
+
+function mesos_agent_get_tasks () {
+  local agent_id=$1
+
+  curl -skSL \
+    -H "Authorization: token=$(dcos config show core.dcos_acs_token)" \
+    -H "Content-Type: application/json" \
+    "$(dcos config show core.dcos_url)/mesos/state" | \
+  jq -er ".frameworks[].tasks[] | select(.slave_id==\"${agent_id}\") | {id: .id, name: .name, framework_id: .framework_id, executor_id: .executor_id, state: .state}"
+}
+
+function mesos_framework_name_for_id() {
+  local framework_id=$1
+  curl -skSL \
+    -H "Authorization: token=$(dcos config show core.dcos_acs_token)" \
+    -H "Content-Type: application/json" \
+    "$(dcos config show core.dcos_url)/mesos/frameworks?framework_id=${framework_id}" | \
+  jq -er '.frameworks[].name'
+}
+
+echo "Getting the list of tasks on ${1} ..." > /dev/stderr
+tasks=$(mesos_agent_get_tasks $1)
+task_names=$(echo "${tasks}" | jq -er '.name')
+
+for framework_id in $(echo "${tasks}" | jq -r .framework_id | uniq); do
+  framework_name=$(mesos_framework_name_for_id ${framework_id})
+  echo "Framework ${framework_name} has tasks on node." > /dev/stderr
+
+  # Trick ahead: It doesnt really matter which sub-command to use, as long as its a SDK
+  # service and name points to the correct framework.
+  pod_list=$(dcos kafka --name="${framework_name}" pod list | jq -er '.[]' 2>/dev/null)
+  [ "${pod_list}" != "" ] || continue
+  for pod in ${pod_list}; do
+    if echo "$task_names" | grep -qE "^${pod}"; then
+      echo "Pod to issue replace for \"${pod}\":" > /dev/stderr
+      echo "dcos kafka --name="${framework_name}" pod replace ${pod}"
+    fi
+  done
+done

--- a/ops/safe_node_decommission.md
+++ b/ops/safe_node_decommission.md
@@ -1,0 +1,41 @@
+# Replace an agent node with data services and/or K8s
+
+## 1. Get a list of nodes to decommission, have their mesos internal agent uuid ready
+```
+agent1-cluster111.team.acme.com 172.31.3.226  85409ae2-9f36-4738-ae5d-712bba77ebc3-S13
+agent2-cluster111.team.acme.com 172.31.14.16  aaf0a62f-a6eb-4c1d-80db-5fdd26fe8008-S2
+[...]
+```
+
+## 2. Move one-by-one: Set the first agent into maintenance mode
+```
+# taken from https://docs.mesosphere.com/1.11/administering-clusters/update-a-node/
+cat <<EOF > maintenance.json
+{
+  "windows" : [
+    {
+      "machine_ids" : [
+        { "hostname" : "agent1-cluster111.team.acme.com", "ip" : "172.31.3.226" }
+      ],
+      "unavailability" : {
+        "start" : { "nanoseconds" : 1 },
+        "duration" : { "nanoseconds" : 3600000000000 }
+      }
+    }
+  ]
+}
+EOF
+bash ../mesos/maintain-agents.sh maintenance.json
+```
+
+## 3. Issue pod replacements for each SDK based service
+```
+eval $(bash pod_replace_drain_agent.sh '85409ae2-9f36-4738-ae5d-712bba77ebc3-S1')
+```
+
+## 4. Check if the node is really drained from SDK services, wait just a little longer, check that the service is healthy and on a new node
+
+## 5. Decommission node
+```
+dcos node decommission 85409ae2-9f36-4738-ae5d-712bba77ebc3-S13
+```


### PR DESCRIPTION
# Use case

Safely remove an agent instance with (potentially) SDK based data frameworks running. 

# Idea

1.  Prepare a list of nodes to decommission (address/name and mesos agent id)
2. For each node:
3. Get a list of running SDK based tasks, remember these
4. shut down mesos-agent via `kill -s SIGUSR1` and `systemctl stop`
5. trigger a `pod replace` for each task found in step above
6. decommission node
7. should also `sleep` a little while to not replace nodes too quickly for data replication and stuff

**The provided script implements the steps 3 and 5.**

Note: 'kafka' was chosen as an arbitrary SDK based package to install the SDK CLI tools. E.g. `dcos package install kafka --cli`. The command doesn't care from which package it comes, all of them support the `pod replace` for ANY SDK based service, including K8s.

# Example
```
grey:ops marv$ bash pod_replace_drain_agent.sh f497df44-5ddd-4807-813a-ddacef17e0d0-S9 > pod_replaces.sh
Getting the list of tasks on f497df44-5ddd-4807-813a-ddacef17e0d0-S9 ...
Framework data-services/confluent-kafka-kerberos has tasks on node.
Pod to issue replace for "kafka-2":
Framework data-services/hdfs has tasks on node.
Pod to issue replace for "data-1":
Framework mom-apps has tasks on node.
Framework kubernetes/kubernetes has tasks on node.
Pod to issue replace for "kube-controller-manager-1":
Framework /logs/elasticsearch has tasks on node.
Pod to issue replace for "data-1":
Pod to issue replace for "master-1":
Framework marathon has tasks on node.
Framework data-services/confluent-kafka has tasks on node.
Pod to issue replace for "kafka-2":
Framework data-services/confluent-zookeeper has tasks on node.
Pod to issue replace for "zookeeper-0":

grey:ops marv$ dcos node ssh --private-ip=172.31.10.48 --master-proxy "sudo systemctl kill -s SIGUSR1 dcos-mesos-slave"
Running `ssh -A -t  54.42.23.1 -- ssh -A -t  172.31.10.48 -- sudo systemctl kill -s SIGUSR1 dcos-mesos-slave`
dcos node ssh --private-ip=172.31.10.48 --master-proxy "sudo systemctl stop dcos-mesos-slave
[...]

grey:ops marv$ bash pod_replaces.sh
{
  "pod": "kafka-2",
  "tasks": ["kafka-2-broker"]
}

{
  "pod": "data-1",
  "tasks": ["data-1-node"]
}

{
  "pod": "kube-controller-manager-1",
  "tasks": ["kube-controller-manager-1-instance"]
}

{
  "pod": "data-1",
  "tasks": ["data-1-node"]
}

{
  "pod": "master-1",
  "tasks": ["master-1-node"]
}

{
  "pod": "kafka-2",
  "tasks": ["kafka-2-broker"]
}

{
  "pod": "zookeeper-0",
  "tasks": [
    "zookeeper-0-metrics",
    "zookeeper-0-server"
  ]
}

grey:ops marv$ dcos node decommission f497df44-5ddd-4807-813a-ddacef17e0d0-S9
Agent f497df44-5ddd-4807-813a-ddacef17e0d0-S9 has been marked as gone.
```

